### PR TITLE
Bug fix on poLCA.entropy.R: number of categories on each variables no…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: poLCA
 Type: Package
 Title: Polytomous variable Latent Class Analysis
-Version: 1.4.1
-Date: 2014-01-09
+Version: 1.4.2
+Date: 2016-02-01
 Author: Drew Linzer <drew@votamatic.org>, 
         Jeffrey Lewis <jblewis@ucla.edu>.
 Maintainer: Drew Linzer <drew@votamatic.org>

--- a/R/poLCA.entropy.R
+++ b/R/poLCA.entropy.R
@@ -1,7 +1,7 @@
 poLCA.entropy <-
 function(lc) {
     K.j <- sapply(lc$probs,ncol)
-    fullcell <- expand.grid(data.frame(sapply(K.j,seq,from=1)))
+    fullcell <- expand.grid(lapply(K.j,seq,from=1))
     P.c <- poLCA.predcell(lc,fullcell)
     return(-sum(P.c * log(P.c),na.rm=TRUE))
 }

--- a/man/poLCA.Rd
+++ b/man/poLCA.Rd
@@ -37,7 +37,7 @@ Model specification: Latent class models have more than one manifest variable, s
 \item{probs.se}{standard errors of estimated class-conditional response probabilities, in the same format as \code{probs}.}
 \item{P}{sizes of each latent class; equal to the mixing proportions in the basic latent class model, or the mean of the priors in the latent class regression model.}
 \item{P.se}{the standard errors of the estimated \code{P}.}
-\item{posterior}{matrix of posterior class membership probabilities; also see function \code{link{poLCA.posterior}}.}
+\item{posterior}{matrix of posterior class membership probabilities; also see function \code{\link{poLCA.posterior}}.}
 \item{predclass}{vector of predicted class memberships, by modal assignment.}
 \item{predcell}{table of observed versus predicted cell counts for cases with no missing values; also see functions \code{\link{poLCA.table}} and \code{\link{poLCA.predcell}}.}
 \item{llik}{maximum value of the log-likelihood.}

--- a/man/poLCA.table.Rd
+++ b/man/poLCA.table.Rd
@@ -6,7 +6,7 @@
 \arguments{
   \item{formula}{A formula expression of the form \code{variable ~ 1} for a one-way frequency distribution, or \code{row ~ column} for two way-tables.}
   \item{condition}{A list containing the values of the manifest variables to hold fixed when creating the table specified by the \code{formula} argument. Setting this to an empty list, \code{condition=list()}, conditions on none of the other manifest variables, producing the marginal frequencies.}
-  \item{lc}{A model object previously estimated using the \code{poLCA} function.}
+  \item{lc}{A model object previously estimated using the \code{\link{poLCA}} function.}
 }
 \details{
 This function outputs predicted cell counts for user-specified combinations of the manifest variables, based on a latent class model estimated by the \code{\link{poLCA}} function.  The \code{predcell} table outputted automatically by \code{poLCA} also contains predicted cell frequencies, but only for cells containing at least one observation.  In contrast, \code{poLCA.table} will calculate predicted cell counts for all cells, including those with zero observations.


### PR DESCRIPTION
Bug fix: current version crash when variables have different number of categories. expand.grid accept a list, so isn't necessary to use data.frame(sapply)), because lapply is enough 