### PR TITLE
Allow larger number of observed items without underflows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: poLCA
 Type: Package
 Title: Polytomous variable Latent Class Analysis
-Version: 1.4.2
-Date: 2016-02-01
+Version: 1.5.0
+Date: 2016-06-04
 Author: Drew Linzer <drew@votamatic.org>, 
         Jeffrey Lewis <jblewis@ucla.edu>.
 Maintainer: Drew Linzer <drew@votamatic.org>
@@ -12,3 +12,5 @@ Description: Latent class analysis and latent class regression models
 License: GPL (>= 2)
 URL: http://dlinzer.github.com/poLCA
 LazyLoad: yes
+NeedsCompilation: yes
+Packaged: 2016-06-04 16:53:43 UTC; jeff

--- a/R/poLCA.R
+++ b/R/poLCA.R
@@ -44,7 +44,7 @@ function(formula,data,nclass=2,maxiter=1000,graphs=FALSE,tol=1e-10,
         ret$probs.start <- ret$probs
         ret$P <- 1
         ret$posterior <- ret$predclass <- prior <- matrix(1,nrow=N,ncol=1)
-        ret$llik <- sum(log(poLCA.ylik.C(poLCA.vectorize(ret$probs),y)))
+        ret$llik <- sum(log(poLCA.ylik.C(poLCA.vectorize(ret$probs),y)) - log(.Machine$double.xmax))
         if (calc.se) {
             se <- poLCA.se(y,x,ret$probs,prior,ret$posterior)
             ret$probs.se <- se$probs           # standard errors of class-conditional response probabilities
@@ -106,7 +106,7 @@ function(formula,data,nclass=2,maxiter=1000,graphs=FALSE,tol=1e-10,
                     } else {
                         prior <- matrix(colMeans(rgivy),nrow=N,ncol=R,byrow=TRUE)
                     }
-                    llik[iter] <- sum(log(rowSums(prior*poLCA.ylik.C(vp,y))))
+                    llik[iter] <- sum(log(rowSums(prior*poLCA.ylik.C(vp,y))) - log(.Machine$double.xmax))
                     dll <- llik[iter]-llik[iter-1]
                     if (is.na(dll)) {
                         error <- TRUE
@@ -170,11 +170,12 @@ function(formula,data,nclass=2,maxiter=1000,graphs=FALSE,tol=1e-10,
         datacell <- compy$datamat
         rownames(datacell) <- NULL
         freq <- compy$freq
+	ylik <- poLCA.ylik.C(poLCA.vectorize(ret$probs),datacell) 
         if (!na.rm) {
-            fit <- matrix(ret$Nobs * (poLCA.ylik.C(poLCA.vectorize(ret$probs),datacell) %*% ret$P))
+            fit <- matrix(ret$Nobs/.Machine$double.xmax * (ylik  %*% ret$P))
             ret$Chisq <- sum((freq-fit)^2/fit) + (ret$Nobs-sum(fit)) # Pearson Chi-square goodness of fit statistic for fitted vs. observed multiway tables
         } else {
-            fit <- matrix(N * (poLCA.ylik.C(poLCA.vectorize(ret$probs),datacell) %*% ret$P))
+            fit <- matrix(N/.Machine$double.xmax * (ylik %*% ret$P))
             ret$Chisq <- sum((freq-fit)^2/fit) + (N-sum(fit))
         }
         ret$predcell <- data.frame(datacell,observed=freq,expected=round(fit,3)) # Table that gives observed vs. predicted cell counts

--- a/R/poLCA.predcell.R
+++ b/R/poLCA.predcell.R
@@ -18,7 +18,7 @@ function(lc,y) {
     if (trap) {
         invisible(NULL)
     } else {
-        ret <- poLCA.ylik.C(poLCA.vectorize(lc$probs),y) %*% lc$P
+        ret <- (poLCA.ylik.C(poLCA.vectorize(lc$probs),y)/.Machine$double.xmax) %*% lc$P
         return(ret)
     }
 }

--- a/R/poLCA.table.R
+++ b/R/poLCA.table.R
@@ -31,7 +31,7 @@ function (formula, condition=NULL, lc) {
         }
         names(sel) <- names(y)
         yc <- expand.grid(sel)
-        predcell <- lc$N * (poLCA.ylik.C(poLCA.vectorize(lc$probs), yc) %*% lc$P)
+        predcell <- lc$N/.Machine$double.xmax * (poLCA.ylik.C(poLCA.vectorize(lc$probs), yc) %*% lc$P)
         if (ncol(mf) > 1) {
             ord <- 1 + (which(names(mf)[1] == names(y)) > which(names(mf)[2] == names(y)))
             if (grp) {

--- a/src/poLCA.c
+++ b/src/poLCA.c
@@ -1,5 +1,7 @@
 #include "R.h"
 
+#define MAX_CLASSES 500  // Maximum number of latent classes
+
 // function: hello
 //    A little test
 void hello(void) {
@@ -25,7 +27,7 @@ void hello(void) {
 //            llik (double *): likelihood vector for the observation
 //
 void ylik(double *probs, int *y, int *obs, int *items,
-		  int *numChoices, int *classes, double *lik) {
+	  int *numChoices, int *classes, double *lik) {
 	int i,j,k;
 	const int citems = *items;
 	const int cclasses = *classes;
@@ -33,12 +35,12 @@ void ylik(double *probs, int *y, int *obs, int *items,
 	const double *firstprobs = probs;
 
 	for (i=0;i<cobs;i++) {
-		for (j=0;j<cclasses;j++) lik[j]=1.0;
+		for (j=0;j<cclasses;j++) lik[j] = DOUBLE_XMAX;
 		probs = (double *) firstprobs;
 		for (k=0;k<citems;k++) {
 			for (j=0;j<cclasses;j++) {
-				if (y[k]>0) lik[j] *= probs[y[k]-1];
-				probs += numChoices[k]; // move pointer to next item
+			   if (y[k]>0) lik[j] *= probs[y[k]-1];
+			   probs += numChoices[k]; // move pointer to next item
 			}
 		}
 		y += citems; // move pointer to next observation
@@ -68,7 +70,7 @@ void postclass(double *prior, double *probs, int *y,
                int *items, int *obs, int *numChoices,
                int *classes, double *posterior) {
 	int i,j,totalChoices;
-	double llik[500]; // Should probably calloc, limits num of classes to 500
+	double llik[MAX_CLASSES]; // Should probably calloc, limits num of classes0
 	double denom;
 	const int citems = *items;
 	const int cobs = *obs;


### PR DESCRIPTION
These changes allow the number of items to be larger than 900 without the calculated class-conditional likelihoods underflowing.   This is accomplished by rescaling those likelihoods by DOUBLE_XMAX.   That rescaling then must be undone in calculations that require the unscaled likelihoods (probabilities).  Ultimately, the number of items is bound in other ways, but this fix allows the number of items to be increased greatly beyond what is currently possible.

I verified that this new code produces identical output on the following example from the vignette:

```{r}
library(poLCA)
data("gss82")
f <- cbind(PURPOSE, ACCURACY, UNDERSTA, COOPERAT) ~ 1
gss.lc <- poLCA(f, gss82, nclass = 3, maxiter = 3000, nrep = 10) 
```

I have not verified that functions provided in **poLCA.predcell.R** or **poLCA.table.R** work correctly after these changes, but they should as the rescaling is trivial in those cases.

Note that as the number of items grows large, certain class-conditional likelihoods/probabilities will still underflow (that is, be calculated to be 0).   This is not a problem in general, but may cause problems in some instances.  The estimation only requires that not all of the class-conditional likelihoods underflow (in which case the posterior class memberships evaluate to NaN and the estimation fails).

This rescaling approach will still eventually fail given a sufficiently large number of items.  We could do more here to allow for an arbitrarily number items, but that would require a larger reengineering of the code and addressing other limitations external to the project (limitations for the number variables used in a formula, for example).

Jeff Lewis
