### PR TITLE
Fix for: Error in ginv(info) : could not find function "ginv"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,3 +14,5 @@ URL: http://dlinzer.github.com/poLCA
 LazyLoad: yes
 NeedsCompilation: yes
 Packaged: 2016-06-04 16:53:43 UTC; jeff
+Imports:
+        MASS

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -11,5 +11,6 @@ S3method(print, poLCA)
 S3method(plot, poLCA)
 S3method(coef, poLCA)
 S3method(vcov, poLCA)
+importFrom(MASS, ginv)
 
 useDynLib(poLCA)


### PR DESCRIPTION
**Issue**
When using this package, I have to attach (`library()`) the `MASS` package (which contains the right `ginv` function presumably) in order to be able to run `poLCA`.

**Solution**
Add MASS::ginv as a dependency